### PR TITLE
fixed a bug when alpha != 0

### DIFF
--- a/SpringRank/SpringRank.py
+++ b/SpringRank/SpringRank.py
@@ -111,15 +111,21 @@ def SpringRank(A, alpha=0):
     if alpha == 0:
         rank = csr_SpringRank(A)
     else:
+        if type(A) == np.ndarray:
+            A = scipy.sparse.csr_matrix(A)
         N = A.shape[0]
-        k_in = np.sum(A, 0)
-        k_out = np.sum(A, 1)
+        k_in = scipy.sparse.csr_matrix.sum(A, 0)
+        k_out = scipy.sparse.csr_matrix.sum(A, 1).T
+
+        k_in = scipy.sparse.diags(np.array(k_in)[0], 0, [N, N], format="csr")
+        k_out = scipy.sparse.diags(np.array(k_out)[0], 0, [N, N], format="csr")
 
         C = A + A.T
-        D1 = np.diag(k_out + k_in)
+        D1 = k_in + k_out
         B = k_out - k_in
-        A = alpha * np.eye(N) + D1 - C
-        A = scipy.sparse.csr_matrix(np.matrix(A))
+        B = B @ np.ones([N, 1])
+
+        A = alpha * scipy.sparse.eye(N) + D1 - C
         rank = scipy.sparse.linalg.bicgstab(A, B)[0]
 
     return np.transpose(rank)


### PR DESCRIPTION
The OLD code emits `ValueError: shapes of A (4, 4) and b (4, 4) are incompatible` when we do the following:

```
from SpringRank import SpringRank
from scipy import sparse
import numpy as np


A = np.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]])
sr = SpringRank.SpringRank(A, alpha=1)
```

The NEW code fixes this problem. It also does simple type checking --- now `A` can be `np.ndarray` OR `scipy.sparse.csr.csr_matrix`. The code above will output the expected SpringRank of 
```
In [*]: sr
Out[*]: array([-0.57142857, -0.14285714,  0.14285714,  0.57142857])
```
