### PR TITLE
Local acc inverse temp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ SpringRank.egg-info
 *.pyc
 dist
 **/.DS_Store
+build

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ print(model.ranks)
 ```
 print(model.get_beta())
 ```
+Note: the value of beta depends on which accuracy metric you want to optimize for, specified by the `inverse_temp_type`parameter. 
+This can be `"global"` for the global accuracy (conditional log likelihood) of Eq. 13 or `"local"` for 
+the local accuracy (mean absolute edge prediction error) of Eq. 12.
 
 **Get the scaled ranks so that a one-rank difference means a 75% win rate**
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,20 @@ This is a sparse `numpy` and `scipy` implementation of SpringRank.
 
 # Installation
 
+To develop your own local version of this code, install in editable mode by running the following from the root directory of this repository:
 ```
-pip install -r requirements.txt
+pip install -e .
 ```
+
+To use this code as-is, either clone this repository and install the package locally:
+```
+pip install .
+```
+
+Alternatively, to install SpringRank directly from PyPI, run:
+```
+pip install springrank
+``` 
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ print(model.predict([3,5]))
 If the `inverse_temp_type` parameter is set to `"global"`, the model will solve for the optimal value of the inverse temperature $\hat{\beta_L}$ using Eq. S39.
 
 If the `inverse_temp_type` parameter is set to `"local"`, the model will solve for the optimal value of the inverse temperature $\hat{\beta_a}$ by minimizing a quantity inversely related to $\sigma_a$ derived from Eq. 12:
-$$\hat{\beta_a} = \min_\beta \sum_{i, j}|A_{ij} - \bar{A}_{ij}P_{ij}(\beta).$$
+```math
+\hat{\beta_a} = \min_\beta \sum_{i, j}|A_{ij} - \bar{A}_{ij}P_{ij}(\beta)|.
+```
 
 If the input adjacency matrix is *perfectly hierarchical*, meaning there are no edges pointing from a lower-ranked node to a higher-ranked node. 
-In this case, there must be no reciprocated edges, so $A_ij = \bar{A}_{ij}$ for all $i, j$ such that $A_{ij} > 0$.
+In this case, there must be no reciprocated edges, so $A_{ij} > 0 \to A_{ji} = 0$ for all $i, j$.
 Because there is a perfect hierarchy, it must also be the case that for all $i, j$ where $A_{ij} > 0$, $s_i > s_j$.
-This means that, in both of the objective functions used to solve for $\beta$, $P_ij = 1$ when $A_{ij} > 0$ (or equivalently $s_i > s_j$) and $P_ij = 0$ when $A_{ij} = 0$ (or equivalently $s_i < s_j$). Thus the optimization yields $\beta = \infty$.
+This means that, in both of the objective functions used to solve for $\beta$, $P_{ij} = 1$ when $A_{ij} > 0$ (or equivalently $s_i > s_j$) and $P_{ij} = 0$ when $A_{ij} = 0$ (or equivalently $s_i < s_j$). Thus the optimization yields $\beta = \infty$.
 While this is mathematically correct, huge values of $\beta$ lead to numerical errors in calls to `model.get_rescaled_ranks` and `model.predict`, so we cap $\beta$ at a large value using the `max_beta` model parameter (default 20). 
 If this cap is reached because of perfectly hierarchical input, a warning will be issued if the `warn_beta` flag is set (default True).
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ print(model.predict([3,5]))
 ```
 
 **Inverse temperature overfitting**
+
 If the `inverse_temp_type` parameter is set to `"global"`, the model will solve for the optimal value of the inverse temperature $\hat{\beta_L}$ using Eq. S39.
 
 If the `inverse_temp_type` parameter is set to `"local"`, the model will solve for the optimal value of the inverse temperature $\hat{\beta_a}$ by minimizing a quantity inversely related to $\sigma_a$ derived from Eq. 12:
@@ -84,7 +85,7 @@ If the input adjacency matrix is *perfectly hierarchical*, meaning there are no 
 In this case, there must be no reciprocated edges, so $A_{ij} > 0 \to A_{ji} = 0$ for all $i, j$.
 Because there is a perfect hierarchy, it must also be the case that for all $i, j$ where $A_{ij} > 0$, $s_i > s_j$.
 This means that, in both of the objective functions used to solve for $\beta$, $P_{ij} = 1$ when $A_{ij} > 0$ (or equivalently $s_i > s_j$) and $P_{ij} = 0$ when $A_{ij} = 0$ (or equivalently $s_i < s_j$). Thus the optimization yields $\beta = \infty$.
-While this is mathematically correct, huge values of $\beta$ lead to numerical errors in calls to `model.get_rescaled_ranks` and `model.predict`, so we cap $\beta$ at a large value using the `max_beta` model parameter (default 20). 
-If this cap is reached because of perfectly hierarchical input, a warning will be issued if the `warn_beta` flag is set (default True).
+While this is mathematically correct, huge values of $\beta$ lead to numerical errors in calls to `model.get_rescaled_ranks` and `model.predict`, so we cap $\beta$ at a large value using the `max_beta` model parameter (default `20`). 
+If this cap is reached because of perfectly hierarchical input, a warning will be issued if the `warn_beta` flag is set (default `True`).
 
 In some other cases where the input is not perfectly hierarchical but the hierarchy is sufficiently rigid so that there are very few upwards or reciprocated edges, optimal values of $\beta$ (especially $\beta_a$) may become extremely large. In these cases, we again cap $\beta$ at `max_beta` and issue a warning if the `warn_beta` flag is set.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ print(model.ranks)
 ```
 print(model.get_beta())
 ```
-Note: the value of beta depends on which accuracy metric you want to optimize for, specified by the `inverse_temp_type`parameter. 
-This can be `"global"` for the global accuracy (conditional log likelihood) of Eq. 13 or `"local"` for 
-the local accuracy (mean absolute edge prediction error) of Eq. 12.
+**Note**: the value of beta depends on which accuracy metric you want to optimize for, specified by the `inverse_temp_type`parameter. 
+This can be `"global"` to optimize for the global accuracy (conditional log likelihood) of Eq. 13 or `"local"` to optimize for 
+the local accuracy (mean absolute edge prediction error) of Eq. 12. See section **Inverse temperature overfitting** below for more technical details.
 
 **Get the scaled ranks so that a one-rank difference means a 75% win rate**
 ```
@@ -71,3 +71,18 @@ model.fit(A)
 print("The probability that an undirected edge between 3 and 5 points from 3 to 5 is:\n")
 print(model.predict([3,5]))
 ```
+
+**Inverse temperature overfitting**
+If the `inverse_temp_type` parameter is set to `"global"`, the model will solve for the optimal value of the inverse temperature $\hat{\beta_L}$ using Eq. S39.
+
+If the `inverse_temp_type` parameter is set to `"local"`, the model will solve for the optimal value of the inverse temperature $\hat{\beta_a}$ by minimizing a quantity inversely related to $\sigma_a$ derived from Eq. 12:
+$$\hat{\beta_a} = \min_\beta \sum_{i, j}|A_{ij} - \bar{A}_{ij}P_{ij}(\beta).$$
+
+If the input adjacency matrix is *perfectly hierarchical*, meaning there are no edges pointing from a lower-ranked node to a higher-ranked node. 
+In this case, there must be no reciprocated edges, so $A_ij = \bar{A}_{ij}$ for all $i, j$ such that $A_{ij} > 0$.
+Because there is a perfect hierarchy, it must also be the case that for all $i, j$ where $A_{ij} > 0$, $s_i > s_j$.
+This means that, in both of the objective functions used to solve for $\beta$, $P_ij = 1$ when $A_{ij} > 0$ (or equivalently $s_i > s_j$) and $P_ij = 0$ when $A_{ij} = 0$ (or equivalently $s_i < s_j$). Thus the optimization yields $\beta = \infty$.
+While this is mathematically correct, huge values of $\beta$ lead to numerical errors in calls to `model.get_rescaled_ranks` and `model.predict`, so we cap $\beta$ at a large value using the `max_beta` model parameter (default 20). 
+If this cap is reached because of perfectly hierarchical input, a warning will be issued if the `warn_beta` flag is set (default True).
+
+In some other cases where the input is not perfectly hierarchical but the hierarchy is sufficiently rigid so that there are very few upwards or reciprocated edges, optimal values of $\beta$ (especially $\beta_a$) may become extremely large. In these cases, we again cap $\beta$ at `max_beta` and issue a warning if the `warn_beta` flag is set.

--- a/springrank/__init__.py
+++ b/springrank/__init__.py
@@ -1,6 +1,4 @@
 from .springrank import SpringRank
 
-__version__ = '0.0.8'
-__authors__ = 'Daniel Larremore'
-
-
+__version__ = "0.0.9"
+__authors__ = "Ben Aoki-Sherwood and Daniel Larremore"

--- a/springrank/springrank.py
+++ b/springrank/springrank.py
@@ -1,23 +1,35 @@
 import numpy as np
 from scipy.sparse import spdiags, csr_matrix, eye
 from scipy.optimize import brentq
+from scipy.optimize import minimize_scalar
 import scipy.sparse.linalg
 import warnings
 from scipy.sparse import SparseEfficiencyWarning
 
-warnings.simplefilter('ignore', SparseEfficiencyWarning)
+warnings.simplefilter("ignore", SparseEfficiencyWarning)
+
 
 class SpringRank:
     """
     A class implementation of the SpringRank algorithm for computing hierarchical rankings
     from directed networks.
-    
+
     Parameters
     ----------
     alpha : float, default=0
         Regularization parameter. If 0, uses Lagrange multiplier approach.
         If > 0, performs L2 regularization.
-        
+    rtol : float, default=1e-05
+        Relative tolerance for the iterative rank solver.
+    atol : float, default=0.0
+        Absolute tolerance for the iterative rank solver.
+    inverse_temp_type : str, default="global"
+        Type of inverse temperature parameter to use for prediction and rank rescaling. Can be "global" for global inverse temperature (optimizes for conditional log-likelihood sigma_L)
+        or "local" for local inverse temperature (optimizes for local accuracy sigma_a).
+    inverse_temp_fit_warning : bool, default=True
+        Whether to issue a warning when the inverse temperature parameter fitting does not converge.
+        If fitting by either root-finding Eq. S39 or minimizing Eq. 12 fails, a warning will be issued and the inverse temperature parameter will default to 20.
+
     Attributes
     ----------
     ranks_ : array-like of shape (n_nodes,)
@@ -25,24 +37,40 @@ class SpringRank:
     is_fitted_ranks_ : bool
         Whether the model has been fitted
     """
-    
-    def __init__(self, alpha=0):
+
+    def __init__(
+        self,
+        alpha=0,
+        rtol=None,
+        atol=None,
+        inverse_temp_type="global",
+        inverse_temp_fit_warning=True,
+    ):
+        assert inverse_temp_type in [
+            "global",
+            "local",
+        ], "inverse_temp_type must be either 'global' or 'local'"
+
         self.alpha = alpha
         self.ranks = None
         self.is_fitted_ranks_ = False
         self.beta = None
         self.is_fitted_beta_ = False
+        self.inverse_temp_type = inverse_temp_type
+        self.warn_beta = inverse_temp_fit_warning
         self.A = None
+        self.rtol = 1e-05 if rtol is None else rtol
+        self.atol = 0.0 if atol is None else atol
 
     def fit(self, A):
         """
         Compute the SpringRank solution for the input adjacency matrix.
-        
+
         Parameters
         ----------
         A : array-like or sparse matrix of shape (n_nodes, n_nodes)
             The adjacency matrix of the directed network
-            
+
         Returns
         -------
         self : object
@@ -64,11 +92,11 @@ class SpringRank:
             self.ranks = self._solve_springrank()
         else:
             self.ranks = self._solve_springrank_regularized()
-            
+
         self.is_fitted_ranks_ = True
 
         return self
-    
+
     def _solve_springrank(self):
         """Implementation of non-regularized SpringRank"""
         N = self.A.shape[0]
@@ -93,18 +121,20 @@ class SpringRank:
         # solve system
         ranks = scipy.sparse.linalg.bicgstab(
             scipy.sparse.csr_matrix(operator),
-            solution_vector
+            solution_vector,
+            rtol=self.rtol,
+            atol=self.atol,
         )[0]
 
         mean_centered_ranks = ranks[:-1] - np.mean(ranks[:-1])
 
         return mean_centered_ranks
-    
+
     def _solve_springrank_regularized(self):
         """Implementation of regularized SpringRank"""
         if isinstance(self.A, np.ndarray):
             self.A = csr_matrix(self.A)
-            
+
         N = self.A.shape[0]
         k_in = self.A.sum(axis=0)
         k_out = self.A.sum(axis=1).T
@@ -118,10 +148,12 @@ class SpringRank:
         B = B @ np.ones([N, 1])
 
         operator = self.alpha * eye(N) + D1 - C
-        ranks = scipy.sparse.linalg.bicgstab(operator, B)[0]
+        ranks = scipy.sparse.linalg.bicgstab(
+            operator, B, rtol=self.rtol, atol=self.atol
+        )[0]
 
         return ranks
-    
+
     @staticmethod
     def _eqs39(beta, s, A):
         """Helper function for inverse temperature calculation
@@ -132,26 +164,88 @@ class SpringRank:
         rows, cols = A.nonzero()
         for idx in range(len(rows)):
             i, j = rows[idx], cols[idx]
-            a_ij = A[i,j]
-            a_ji = A[j,i]
-            if a_ji==0: 
-                # This ensures that both (i,j) and (j,i) entries are counted
-                # in the sum, which is guaranteed for reciprocated edges
-                # but would otherwise be skipped when i->j is unreciprocated;
-                # that is, we force a double-count when i->j but j-/>i
-                x += 2*(s[i] - s[j]) * (a_ij - (a_ij + a_ji) / 
-                                     (1 + np.exp(-2 * beta * (s[i] - s[j]))))
-            else: 
-                x += (s[i] - s[j]) * (a_ij - (a_ij + a_ji) / 
-                                     (1 + np.exp(-2 * beta * (s[i] - s[j]))))
+            a_ij = A[i, j]
+            a_ji = A[j, i]
+            x += (s[i] - s[j]) * (
+                a_ij - (a_ij + a_ji) / (1 + np.exp(-2 * beta * (s[i] - s[j])))
+            )
         return x
-    
+
+    @staticmethod
+    def _eq12_ish(beta, s, A):
+        """
+        In the paper, Eq 12 is the 'local' accuracy sigma_a, which we wish to max
+        Equally, we can minimize 2M*(1-sigma_a), which is what this _eq12_ish equation is
+        """
+        x = 0
+        rows, cols = A.nonzero()
+        for idx in range(len(rows)):
+            i, j = rows[idx], cols[idx]
+            a_ij = A[i, j]
+            a_ji = A[j, i]
+            a_ij_bar = a_ij + a_ji
+            x += np.abs(a_ij - a_ij_bar / (1 + np.exp(-2 * beta * (s[i] - s[j]))))
+        return x
+
     def _get_inverse_temperature(self):
-        """Calculate inverse temperature parameter"""
-        MLE = brentq(self._eqs39, 0.01, 20, args=(self.ranks, self.A))
-        return MLE
-    
+        if self.inverse_temp_type == "global":
+            return self._get_inverse_temperature_global()
+        elif self.inverse_temp_type == "local":
+            return self._get_inverse_temperature_local()
+
+    def _get_inverse_temperature_global(self):
+        """
+        Calculates global inverse temperature parameter beta_L that maximizes the conditional log-likelihood sigma_L (Eq. 13) by performing root-finding on Eq. S39.
+        This is the global inverse temperature parameter used for prediction and rank rescaling if the model is fitted with inverse_temp_type="global".
+        Root-finding is performed using Brent's method (brentq) over the interval [0.01, 20]. If root-finding fails, beta_L defaults to 20.
+        """
+        try:
+            MLE = brentq(self._eqs39, 0.01, 20, args=(self.ranks, self.A))
+            return MLE
+        except ValueError as e:
+            if self.warn_beta:
+                warnings.warn(
+                    f"Root-finding Eq. S39 for global inverse temperature failed, indicating potential overfitting. Defaulting to beta_L = 20."
+                )
+            return 20
+
+    def _get_inverse_temperature_local(self):
+        """
+        Calculates local inverse temperature parameter beta_a that minimizes the local accuracy sigma_a (Eq. 12) by minimizing an objective function that approximates the negative of sigma_a.
+        This is the local inverse temperature parameter used for prediction and rank rescaling if the model is fitted with inverse_temp_type="local".
+        The minimization over a grid of beta values from 0 to 100 using local optimization. If the resulting local minimum is very large (> 20),
+        the model is likely overfitting, and beta_a is capped at 20 with a warning.
+        """
+        bounds = (0, 100)
+        with np.errstate(over="ignore"):
+            n_grid_points = 10
+            beta_grid = np.linspace(
+                bounds[0], bounds[1], n_grid_points + 1
+            )  # take the best of the 10 local optima
+            results = []
+
+            for i in range(n_grid_points):
+                res = minimize_scalar(
+                    lambda beta: self._eq12_ish(beta, self.ranks, self.A),
+                    bounds=(beta_grid[i], beta_grid[i + 1]),
+                )
+                results.append(res)
+
+            result = min(results, key=lambda r: r.fun)
+
+        beta_a = result.x
+        if beta_a > 20 and self.warn_beta:
+            print(
+                "Warning: Minimizing Eq 12 for local inverse temperature yielded a large local optimum, indicating potential overfitting. Capping beta_a at 20."
+            )
+        return min(beta_a, 20)
+
     def get_beta(self):
+        """
+        Get the inverse temperature parameter beta.
+        If the inverse_temp_type parameter is "global", returns the global inverse temperature parameter beta_L.
+        If the inverse_temp_type parameter is "local", returns the local inverse temperature parameter beta_a.
+        """
         if self.is_fitted_beta_ == False:
             self.beta = self._get_inverse_temperature()
             self.is_fitted_beta_ = True
@@ -162,10 +256,11 @@ class SpringRank:
         if self.is_fitted_beta_ == False:
             self.beta = self._get_inverse_temperature()
             self.is_fitted_beta_ = True
-        scaling_factor = 1 / (np.log(target_scale / (1 - target_scale)) / 
-                            (2 * self.beta))
+        scaling_factor = 1 / (
+            np.log(target_scale / (1 - target_scale)) / (2 * self.beta)
+        )
         return self.ranks * scaling_factor
-    
+
     def predict(self, ij_pair):
         """Predict probability that i -> j in a pair [i,j]"""
         if not self.is_fitted_ranks_:
@@ -173,7 +268,9 @@ class SpringRank:
         i = ij_pair[0]
         j = ij_pair[1]
         if not (0 <= i < self.A.shape[0] and 0 <= j < self.A.shape[0]):
-            raise ValueError(f"Indices {i}, {j} out of bounds for matrix of size {self.A.shape[0]}")
+            raise ValueError(
+                f"Indices {i}, {j} out of bounds for matrix of size {self.A.shape[0]}"
+            )
         if self.is_fitted_beta_ == False:
             self.beta = self._get_inverse_temperature()
             self.is_fitted_beta_ = True

--- a/springrank/springrank.py
+++ b/springrank/springrank.py
@@ -8,7 +8,6 @@ from scipy.sparse import SparseEfficiencyWarning
 
 warnings.simplefilter("ignore", SparseEfficiencyWarning)
 
-
 class SpringRank:
     """
     A class implementation of the SpringRank algorithm for computing hierarchical rankings
@@ -29,6 +28,9 @@ class SpringRank:
     inverse_temp_fit_warning : bool, default=True
         Whether to issue a warning when the inverse temperature parameter fitting does not converge.
         If fitting by either root-finding Eq. S39 or minimizing Eq. 12 fails, a warning will be issued and the inverse temperature parameter will default to 20.
+    max_beta : float, default=20
+        Maximum value for the inverse temperature parameter. 
+        If the optimal beta exceeds this value or if the model is fit to a perfect hierarchy, beta will be capped at this value.
 
     Attributes
     ----------
@@ -45,6 +47,7 @@ class SpringRank:
         atol=None,
         inverse_temp_type="global",
         inverse_temp_fit_warning=True,
+        max_beta=20
     ):
         assert inverse_temp_type in [
             "global",
@@ -58,6 +61,7 @@ class SpringRank:
         self.is_fitted_beta_ = False
         self.inverse_temp_type = inverse_temp_type
         self.warn_beta = inverse_temp_fit_warning
+        self.max_beta = max_beta
         self.A = None
         self.rtol = 1e-05 if rtol is None else rtol
         self.atol = 0.0 if atol is None else atol
@@ -156,8 +160,9 @@ class SpringRank:
 
     @staticmethod
     def _eqs39(beta, s, A):
-        """Helper function for inverse temperature calculation
-        Memory-efficient version of eqs39 that works with sparse matrices.
+        """
+        Helper function for global inverse temperature optimization.
+        Memory-efficient version of Eq S39 that works with sparse matrices.
         Instead of converting to dense matrix, we iterate over nonzero elements.
         """
         x = 0
@@ -174,8 +179,9 @@ class SpringRank:
     @staticmethod
     def _eq12_ish(beta, s, A):
         """
-        In the paper, Eq 12 is the 'local' accuracy sigma_a, which we wish to max
-        Equally, we can minimize 2M*(1-sigma_a), which is what this _eq12_ish equation is
+        Helper function for local inverse temperature optimization. 
+        In the paper, we optimize beta_a to be the value that maximizes sigma_a in Eq 12.
+        Equivalently, we can minimize 2M*(1-sigma_a), which is what this _eq12_ish equation is.
         """
         x = 0
         rows, cols = A.nonzero()
@@ -188,7 +194,23 @@ class SpringRank:
         return x
 
     def _get_inverse_temperature(self):
-        if self.inverse_temp_type == "global":
+        """
+        Calculates the temperature parameter used for prediction and rank rescaling.
+        If self.inverse_temp_type = "global", computes the global inverse temperature parameter beta_L that maximizes the conditional log-likelihood sigma_L (Eq. 13).
+        If self.inverse_temp_type = "local", computes the local inverse temperature parameter beta_a that maximizes the local accuracy sigma_a (Eq. 12).
+
+        If the adjacency matrix is perfectly hierarchical (i.e., all edges point upward), the optimal beta is infinite, so calling this function will result in a warning and a beta value equal to the self.max_beta instance variable.
+        Also, even in cases where the hierarchy is not perfect but is very rigid, the model may overfit, leading to a very large optimal beta value.
+        If the optimal beta exceeds self.max_beta, it will be capped at self.max_beta, and a warning will be issued.
+        """
+
+        if self._get_proportion_upward_edges() == 0.0:
+            if self.warn_beta:
+                print(
+                    f"Warning: adjacency matrix is perfectly hierarchical, so the optimal beta is infinite. Capping beta at {self.max_beta}."
+                )
+            return self.max_beta
+        elif self.inverse_temp_type == "global":
             return self._get_inverse_temperature_global()
         elif self.inverse_temp_type == "local":
             return self._get_inverse_temperature_local()
@@ -200,14 +222,17 @@ class SpringRank:
         Root-finding is performed using Brent's method (brentq) over the interval [0.01, 20]. If root-finding fails, beta_L defaults to 20.
         """
         try:
-            MLE = brentq(self._eqs39, 0.01, 20, args=(self.ranks, self.A))
-            return MLE
-        except ValueError as e:
-            if self.warn_beta:
-                warnings.warn(
-                    f"Root-finding Eq. S39 for global inverse temperature failed, indicating potential overfitting. Defaulting to beta_L = 20."
-                )
-            return 20
+            MLE = brentq(self._eqs39, 0.01, 100, args=(self.ranks, self.A))
+            if MLE <= self.max_beta:
+                return MLE
+        except ValueError:
+            pass
+
+        if self.warn_beta:
+            print(
+                "Warning: Root-finding Eq S39 for beta_L indicates model overfitting because many large beta values are optimal. Capping beta_L at 20. If this is not desired, try increasing the model regularization."
+            )
+        return self.max_beta
 
     def _get_inverse_temperature_local(self):
         """
@@ -234,11 +259,19 @@ class SpringRank:
             result = min(results, key=lambda r: r.fun)
 
         beta_a = result.x
-        if beta_a > 20 and self.warn_beta:
+        if beta_a > self.max_beta and self.warn_beta:
             print(
                 "Warning: Minimizing Eq 12 for local inverse temperature yielded a large local optimum, indicating potential overfitting. Capping beta_a at 20."
             )
-        return min(beta_a, 20)
+        return min(beta_a, self.max_beta)
+
+    def _get_proportion_upward_edges(self):
+        """Computes the proportion of edges that point upward in the ranking. Used to determine if the adjacency matrix is perfectly hierarchical."""
+        sorted_indices = np.argsort(self.ranks)[::-1]
+        sorted_A = self.A[sorted_indices][:, sorted_indices]
+        if scipy.sparse.issparse(sorted_A):
+            sorted_A = sorted_A.toarray()
+        return np.tril(sorted_A, k=-1).sum() / sorted_A.sum()
 
     def get_beta(self):
         """

--- a/springrank/springrank.py
+++ b/springrank/springrank.py
@@ -222,7 +222,7 @@ class SpringRank:
         Root-finding is performed using Brent's method (brentq) over the interval [0.01, 20]. If root-finding fails, beta_L defaults to 20.
         """
         try:
-            MLE = brentq(self._eqs39, 0.01, 100, args=(self.ranks, self.A))
+            MLE = brentq(self._eqs39, 0.01, 20, args=(self.ranks, self.A))
             if MLE <= self.max_beta:
                 return MLE
         except ValueError:
@@ -238,12 +238,12 @@ class SpringRank:
         """
         Calculates local inverse temperature parameter beta_a that minimizes the local accuracy sigma_a (Eq. 12) by minimizing an objective function that approximates the negative of sigma_a.
         This is the local inverse temperature parameter used for prediction and rank rescaling if the model is fitted with inverse_temp_type="local".
-        The minimization over a grid of beta values from 0 to 100 using local optimization. If the resulting local minimum is very large (> 20),
+        The minimization over a grid of beta values from 0 to 30 using local optimization. If the resulting local minimum is very large (> 20),
         the model is likely overfitting, and beta_a is capped at 20 with a warning.
         """
-        bounds = (0, 100)
+        bounds = (0, 30)
         with np.errstate(over="ignore"):
-            n_grid_points = 10
+            n_grid_points = 5
             beta_grid = np.linspace(
                 bounds[0], bounds[1], n_grid_points + 1
             )  # take the best of the 10 local optima
@@ -266,9 +266,13 @@ class SpringRank:
         return min(beta_a, self.max_beta)
 
     def _get_proportion_upward_edges(self):
-        """Computes the proportion of edges that point upward in the ranking. Used to determine if the adjacency matrix is perfectly hierarchical."""
+        """
+        Computes the proportion of edges that point upward in the ranking. 
+        Used to determine if the adjacency matrix is perfectly hierarchical.
+        """
         sorted_indices = np.argsort(self.ranks)[::-1]
         sorted_A = self.A[sorted_indices][:, sorted_indices]
+
         if scipy.sparse.issparse(sorted_A):
             sorted_A = sorted_A.toarray()
         return np.tril(sorted_A, k=-1).sum() / sorted_A.sum()


### PR DESCRIPTION
Implement inverse temperature parameter fitting based on local accuracy (Eq. 12). Users can now specify which inverse temperature type to use with the `inverse_temp_type` paramter. Options are: 
- "global" optimizes Eq. S39 to get $\beta_L$
- "local" optimizes a variant of Eq. 12 to get $\beta_a$

Also, the model now checks for overfitting when solving for $\beta$. If the input network is perfectly hierarchical, the optimal value of $\beta$ is infinity, so we cap $\beta$ using a new parameter `max_beta` (default `20`). In other cases where the optimal value of $\beta$ is very large, overfitting is likely, so we also cap $\beta$ and issue a warning to the user if the `warn_beta` flag is set (default `True`). This prevents numerical issues when predicting edge directions and rescaling ranks. 